### PR TITLE
Configure theme (SHOOP-2451)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sphinx-shoop-theme"]
+	path = sphinx-shoop-theme
+	url = git@github.com:shoopio/sphinx-shoop-theme.git

--- a/source/_themes/sphinx_shoop_theme
+++ b/source/_themes/sphinx_shoop_theme
@@ -1,0 +1,1 @@
+../../sphinx-shoop-theme/sphinx_shoop_theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -107,7 +107,8 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'sphinx_shoop_theme'
+html_theme_path = ['_themes']
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Configure Sphinx to use Sphinx Shoop Theme.

The theme is installed as a submodule and symlinked to source/_themes.
