### PR TITLE
Fix warning in build while copying static files (SHOOP-2419)

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -139,7 +139,7 @@ html_theme_path = [sphinx_shoop_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
Based on https://github.com/rtfd/readthedocs.org/issues/1776 this might
do the trick
